### PR TITLE
fix: add rt_field = tags to testrt schema in LXC install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,41 @@ CT → Resources → Add → Bind Mount
 
 Environment variables are configured in `/etc/eldoar.env` inside the container.
 
+### Optional: Thumbnail Caching via Reverse Proxy
+
+If you run ELDOAR behind a reverse proxy (e.g. **nginx Proxy Manager** in front of a Docker or LXC deployment), you can cache thumbnails there instead of hitting the Perl process for every `.jpg` request.
+
+In **nginx Proxy Manager**, open the proxy host → *Advanced* tab and add:
+
+```nginx
+location ~* \.jpg$ {
+    expires 30d;
+    add_header Cache-Control "public, no-transform";
+    proxy_hide_header Set-Cookie;
+}
+```
+
+For a plain **nginx** config:
+
+```nginx
+server {
+    listen 80;
+
+    location ~* \.jpg$ {
+        expires 30d;
+        add_header Cache-Control "public, no-transform";
+        proxy_hide_header Set-Cookie;
+        proxy_pass http://127.0.0.1:3000;
+    }
+
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+}
+```
+
 ---
 
 ## Featuers / Ideas

--- a/dancerApp.pl
+++ b/dancerApp.pl
@@ -101,21 +101,11 @@ get '/file/**' => sub {
     my @foo = @{$file};
     my $filename = "" . join("/", @foo);
     debug $filename;
-
-    # Optional: set cache headers for thumbnails (.jpg)
-    # Alternatively configure this in a nginx reverse proxy:
-    #   location ~* \.(jpg|jpeg)$ {
-    #     expires 30d;
-    #     add_header Cache-Control "public, no-transform";
-    #     proxy_hide_header Set-Cookie;
-    #   }
-    # if ($filename =~ /\.jpg$/i) {
-    #     header 'Cache-Control' => 'public, max-age=2592000, no-transform';
-    #     header 'Expires'       => time2str(time + 2592000);
-    # }
-
+    
     my $home = $ENV{'ELDOAR_HOME'} || '/app';
     return send_file( "$home/$filename", system_path => 1 );
+
+    # return 'You want to download :"' . $sfoo . '"';
 };
 
 del '/file/:id' => sub {

--- a/dancerApp.pl
+++ b/dancerApp.pl
@@ -101,11 +101,21 @@ get '/file/**' => sub {
     my @foo = @{$file};
     my $filename = "" . join("/", @foo);
     debug $filename;
-    
+
+    # Optional: set cache headers for thumbnails (.jpg)
+    # Alternatively configure this in a nginx reverse proxy:
+    #   location ~* \.(jpg|jpeg)$ {
+    #     expires 30d;
+    #     add_header Cache-Control "public, no-transform";
+    #     proxy_hide_header Set-Cookie;
+    #   }
+    # if ($filename =~ /\.jpg$/i) {
+    #     header 'Cache-Control' => 'public, max-age=2592000, no-transform';
+    #     header 'Expires'       => time2str(time + 2592000);
+    # }
+
     my $home = $ENV{'ELDOAR_HOME'} || '/app';
     return send_file( "$home/$filename", system_path => 1 );
-
-    # return 'You want to download :"' . $sfoo . '"';
 };
 
 del '/file/:id' => sub {

--- a/lxc/eldoar.sh
+++ b/lxc/eldoar.sh
@@ -337,6 +337,7 @@ table testrt {
   path              = /var/lib/manticore/testrt
 
   rt_field          = content
+  rt_field          = tags
   rt_attr_uint      = gid
   rt_attr_string    = title
   rt_attr_timestamp = doc_timestamp


### PR DESCRIPTION
minor fix for having `tags` field on LXC installation